### PR TITLE
The accent on the "n" letter raises a nasty encoding error

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "name": "wavesoftware-xtreemfs",
   "version": "0.1.0",
-  "author": "Krzysztof Suszyński",
+  "author": "Krzysztof Suszynski",
   "summary": "The XtreemFS module allows you to easily manage XtreemFS installation, volumes and mounts",
   "license": "Apache 2.0",
   "source": "git://github.com/wavesoftware/puppet-xtreemfs.git",


### PR DESCRIPTION
/usr/lib/ruby/vendor_ruby/json/common.rb:155:in `encode': "\xC5" on
US-ASCII (Encoding::InvalidByteSequenceError)

Corrected when we replace the "ń" with "n"…

Sorry :(
