### PR TITLE
Better order for "storage" configuration

### DIFF
--- a/manifests/internal/configure/storage.pp
+++ b/manifests/internal/configure/storage.pp
@@ -10,15 +10,15 @@ class xtreemfs::internal::configure::storage (
       "set dir_service.host ${dir_service}",
       "set object_dir ${object_dir}/objs",
     ],
-    before  => Anchor[$xtreemfs::internal::workflow::packages],
+    require => Anchor[$xtreemfs::internal::workflow::packages],
     notify  => Anchor[$xtreemfs::internal::workflow::configure],
   }
   
   file { $object_dir:
-    ensure => 'directory',
-    owner  => 'xtreemfs',
-    group  => 'xtreemfs',
-    before => Anchor[$xtreemfs::internal::workflow::packages],
-    notify => Anchor[$xtreemfs::internal::workflow::configure],
+    ensure  => 'directory',
+    owner   => 'xtreemfs',
+    group   => 'xtreemfs',
+    require => Anchor[$xtreemfs::internal::workflow::packages],
+    notify  => Anchor[$xtreemfs::internal::workflow::configure],
   }
 }


### PR DESCRIPTION
In order to avoid puppet error, the orders need to be a bit different:
- the user is created by the package, thus we need it in order to create
  the directory.
- it might be better to get the package configuration file before we
  edit it ;)

Main aim: get a flawless puppet run so that we can build any image
without a second run.

This solves #2
